### PR TITLE
fix for incompatibility with anti:modals modal templates

### DIFF
--- a/jquery.datetimepicker.css
+++ b/jquery.datetimepicker.css
@@ -11,7 +11,7 @@
 	padding-left: 0;
 	padding-top: 2px;
 	position: absolute;
-	z-index: 9999;
+	z-index: 65537;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	display: none;


### PR DESCRIPTION
Modal templates built by anti:modals have a base z-index of 65536. Datetimepicker currently has a base z-index of 9999, so that the picker is not visible when used in modal templates. Bumping the z-index for datetimepicker one unit above that for anti:modals ensures the picker will be visible in modal templates.
